### PR TITLE
Non-alloc counter extraction and more general event and error handling

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -91,7 +91,7 @@ jni/%.o: jni/%.c
 jni/genconst.o: jni/events_list.c jni/errors_list.c
 
 jni/events_list.c: ${PAPI_EVENTS}
-	${GREP} -v PAPI_END $< | ${AWK} '/^enum/ { start = 1; }  /#define/ { if (start) printf "\tPRINT_CONSTX(%s);\n", $$2 }' > $@
+	${GREP} -v PAPI_END $< | ${AWK} '/^enum/ { start = 1; }  /#define/ { if (start) printf "\tPRINT_EVENT(%s);\n", $$2 }' > $@
 
 jni/errors_list.c: ${PAPI_H}
 	cat $< | ${AWK} '/PAPI_OK/ { start = 1; }  /PAPI_NUM_ERRORS/ {start=0} /#define/ { if (start) { n = $$2; s=$$5; for (i = 6; i < NF; ++i) {s = s " " $$i}; printf "\tPRINT_ERROR(%s, \"%s\");\n", n, s} }' > $@

--- a/Makefile.template
+++ b/Makefile.template
@@ -52,6 +52,7 @@ JAVA_JUNIT_TESTS = papi.EventSetApiTest
 PAPI_PATH = %papi_path%
 PAPI_LIBRARY_PATH = %papi_library_path%
 PAPI_EVENTS ?= ${PAPI_PATH}/include/papiStdEventDefs.h
+PAPI_H ?= ${PAPI_PATH}/include/papi.h
 
 all: libpapijava.so papi.jar papi-tests.jar
 
@@ -87,10 +88,13 @@ jni/*.c: jni/$(WRAPPER_CLASS_C_HEADER)
 jni/%.o: jni/%.c
 	$(CC) $(CFLAGS) -c -o $@ $(CFLAGS_JNI) $<
 
-jni/genconst.o: jni/events_list.c
+jni/genconst.o: jni/events_list.c jni/errors_list.c
 
 jni/events_list.c: ${PAPI_EVENTS}
 	${GREP} -v PAPI_END $< | ${AWK} '/^enum/ { start = 1; }  /#define/ { if (start) printf "\tPRINT_CONSTX(%s);\n", $$2 }' > $@
+
+jni/errors_list.c: ${PAPI_H}
+	cat $< | ${AWK} '/PAPI_OK/ { start = 1; }  /PAPI_NUM_ERRORS/ {start=0} /#define/ { if (start) { n = $$2; s=$$5; for (i = 6; i < NF; ++i) {s = s " " $$i}; printf "\tPRINT_ERROR(%s, \"%s\");\n", n, s} }' > $@
 
 jni/genconst.bin: jni/genconst.o
 	$(CC) -o $@ $(CFLAGS) -lpapi $< $(LDFLAGS)

--- a/jni/genconst.c
+++ b/jni/genconst.c
@@ -37,7 +37,9 @@
 	" */\n\n" \
 	"package papi;\n" \
 	"\n" \
-	"public class Constants {"
+	"public class Constants {\n" \
+	"\tpublic static final java.util.Map<Integer, String> ERRORS = new java.util.HashMap<>();\n" \
+	"\tpublic static final java.util.Map<String, Integer> EVENTS = new java.util.HashMap<>();\n"
 
 #define JAVA_FOOTER "}"
 
@@ -47,8 +49,17 @@
 #define PRINT_CONST(name) \
 	printf("\tpublic static final int %s = %d;\n", #name, name);
 
+#define PRINT_CONST2(name, _)						\
+	printf("\tpublic static final int %s = %d;\n", #name, name);
+
 #define PRINT_CONSTX(name) \
 	printf("\tpublic static final int %s = 0x%x;\n", #name, name);
+
+#define PRINT_ERROR_DESCRIPTION(name, description)					\
+	printf("\t\tERRORS.put(%s, \"%s\");\n", #name, description);
+
+#define PRINT_EVENT_MAPPING(name) \
+	printf("\t\tEVENTS.put(\"%s\", %s);\n", #name, #name);
 
 int main() {
 	printf("%s\n", JAVA_HEADER);
@@ -56,11 +67,29 @@ int main() {
 	PRINT_CONSTX(PAPI_VER_CURRENT);
 
 	START_GROUP("Error codes");
-	PRINT_CONST(PAPI_OK);
-	PRINT_CONST(PAPI_EINVAL);
+#define PRINT_ERROR PRINT_CONST2
+#include "errors_list.c"
+#undef PRINT_ERROR
 
 	START_GROUP("Preset events");
+#define PRINT_EVENT PRINT_CONSTX
 #include "events_list.c"
+#undef PRINT_EVENT
+
+	START_GROUP("Error code descriptions");
+	printf("\tstatic {\n");
+#define PRINT_ERROR PRINT_ERROR_DESCRIPTION
+#include "errors_list.c"
+#undef PRINT_ERROR
+	printf("\t}\n");
+
+	START_GROUP("Event names map");
+	printf("\tstatic {\n");
+#define PRINT_EVENT PRINT_EVENT_MAPPING
+#include "events_list.c"
+#undef PRINT_ERROR
+	printf("\t}\n");
+
 
 	printf("%s\n", JAVA_FOOTER);
 

--- a/src/papi/EventSet.java
+++ b/src/papi/EventSet.java
@@ -62,9 +62,20 @@ public class EventSet {
 		PapiException.throwOnError(rc, "starting event set");
 	}
 
-	public void stop() throws PapiException {
+	/**
+	 * Stops a running event set, unless the event set wasn't running
+	 *
+	 * @return Event set was not running, no new events
+	 */
+	public boolean stop() throws PapiException {
 		int rc = Wrapper.eventSetStop(eventId[0], counters);
-		PapiException.throwOnError(rc, "stopping events");
+		if (rc == Constants.PAPI_ENOTRUN) {
+			return false;
+		} else if (rc == Constants.PAPI_OK) {
+			return true;
+		}
+		PapiException.throwOnError(rc, "resetting events");
+		return true;
 	}
 
 	public long[] getCounters() {

--- a/src/papi/EventSet.java
+++ b/src/papi/EventSet.java
@@ -70,4 +70,18 @@ public class EventSet {
 	public long[] getCounters() {
 		return Arrays.copyOf(counters, counters.length);
 	}
+
+	public long getCounter(int index) {
+		return this.counters[index];
+	}
+
+	public int size() {
+		return this.counters.length;
+	}
+
+	public void addCountersTo(long[] dest) {
+		for (int i = 0; i < this.counters.length; ++i) {
+			dest[i] += this.counters[i];
+		}
+	}
 }

--- a/src/papi/PapiException.java
+++ b/src/papi/PapiException.java
@@ -32,7 +32,7 @@ public class PapiException extends RuntimeException {
 	private static final long serialVersionUID = 1L;
 
 	public PapiException(int rc, String reason) {
-		super(reason);
+		super(reason + " [error code = " + rc + "]");
 	}
 
 	public static void throwOnError(int rc, String reason) throws PapiException {


### PR DESCRIPTION
This patch adds:
- Operations to extract counters w/o the need to allocate a result array
- Extraction of error codes and descriptions from `papi.h`
- Error code and code explanation when raising a PAPI exception
- A map with performance counters (by name)